### PR TITLE
feat(api): 公開フォーム5本を集約ハブ labs-enabler へ best-effort 転送

### DIFF
--- a/spin-component/src/api/fanclub.rs
+++ b/spin-component/src/api/fanclub.rs
@@ -24,7 +24,18 @@ pub async fn register(req: Request, origin: &str) -> Response {
 
     // Register new member with a promo code
     match kv::create_fanclub_member(&email) {
-        Ok(_member) => send_login_and_respond(&email, origin).await,
+        Ok(_member) => {
+            // Best-effort forward to the labs-enabler aggregation hub (new
+            // registrations only — not the existing-member re-login path).
+            crate::inquiry_hub::forward(serde_json::json!({
+                "slug": "enablerdao-fanclub",
+                "email": email,
+                "extra": {"kind": "fanclub", "source": "enablerdao"},
+                "utm_source": "enablerdao",
+            })).await;
+
+            send_login_and_respond(&email, origin).await
+        }
         Err(_) => json_error(500, "登録に失敗しました", origin),
     }
 }

--- a/spin-component/src/api/feedback.rs
+++ b/spin-component/src/api/feedback.rs
@@ -24,6 +24,16 @@ pub async fn submit(req: Request) -> Response {
         crate::email::send_feedback_notification(&api_key, message, contact).await;
     }
 
+    // Best-effort forward to the labs-enabler aggregation hub.
+    let hub_email = if contact.contains('@') { contact } else { "" };
+    crate::inquiry_hub::forward(serde_json::json!({
+        "slug": "enablerdao-feedback",
+        "email": hub_email,
+        "message": message,
+        "extra": {"kind": "feedback", "contact": contact, "source": "enablerdao"},
+        "utm_source": "enablerdao",
+    })).await;
+
     let resp = serde_json::json!({
         "ok": true,
         "message": "フィードバックを送信しました。ありがとうございます！",

--- a/spin-component/src/api/ideas.rs
+++ b/spin-component/src/api/ideas.rs
@@ -38,6 +38,16 @@ pub async fn create(req: Request) -> Response {
                 crate::email::send_idea_notification(&api_key, &idea.title, &idea.nickname).await;
             }
 
+            // Best-effort forward to the labs-enabler aggregation hub.
+            crate::inquiry_hub::forward(serde_json::json!({
+                "slug": "enablerdao-ideas",
+                "name": nickname,
+                "email": email,
+                "message": format!("{title}\n\n{detail}"),
+                "extra": {"kind": "idea", "category": category, "source": "enablerdao"},
+                "utm_source": "enablerdao",
+            })).await;
+
             let body = serde_json::to_vec(&idea).unwrap_or_default();
             json_response(201, body)
         }

--- a/spin-component/src/api/newsletter.rs
+++ b/spin-component/src/api/newsletter.rs
@@ -28,6 +28,14 @@ pub async fn subscribe(req: Request, origin: &str) -> Response {
                 crate::email::send_welcome(&api_key, &email).await;
             }
 
+            // Best-effort forward to the labs-enabler aggregation hub.
+            crate::inquiry_hub::forward(serde_json::json!({
+                "slug": "enablerdao-newsletter",
+                "email": email,
+                "extra": {"kind": "newsletter", "source": "enablerdao"},
+                "utm_source": "enablerdao",
+            })).await;
+
             let resp = serde_json::json!({
                 "ok": true,
                 "message": "ご登録ありがとうございます！",

--- a/spin-component/src/api/qa.rs
+++ b/spin-component/src/api/qa.rs
@@ -14,7 +14,7 @@ pub fn list() -> Response {
 /// `POST /api/qa` — submit a new question.
 ///
 /// Expected JSON body: `{ "question", "asker" }`
-pub fn create(req: Request) -> Response {
+pub async fn create(req: Request) -> Response {
     let body = req.body();
     let data: serde_json::Value = match serde_json::from_slice(body) {
         Ok(v) => v,
@@ -30,6 +30,15 @@ pub fn create(req: Request) -> Response {
 
     match kv::create_question(question, asker) {
         Ok(item) => {
+            // Best-effort forward to the labs-enabler aggregation hub.
+            crate::inquiry_hub::forward(serde_json::json!({
+                "slug": "enablerdao-qa",
+                "name": asker,
+                "message": question,
+                "extra": {"kind": "qa", "source": "enablerdao"},
+                "utm_source": "enablerdao",
+            })).await;
+
             let body = serde_json::to_vec(&item).unwrap_or_default();
             json_response(201, body)
         }

--- a/spin-component/src/inquiry_hub.rs
+++ b/spin-component/src/inquiry_hub.rs
@@ -1,0 +1,19 @@
+/// Best-effort forwarding of public form submissions to the labs-enabler
+/// aggregation hub. Fire-and-forget: any failure is silently ignored so it
+/// never affects the user-facing request, the KV write, or the email path.
+
+use spin_sdk::http::{Method, Request, Response};
+
+const HUB_URL: &str = "https://labs-enabler.fly.dev/api/inquiry";
+
+/// 集約ハブへ best-effort 転送。失敗は無視。
+pub async fn forward(payload: serde_json::Value) {
+    let Ok(body) = serde_json::to_vec(&payload) else { return };
+    let req = Request::builder()
+        .method(Method::Post)
+        .uri(HUB_URL)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .build();
+    let _: Result<Response, _> = spin_sdk::http::send(req).await;
+}

--- a/spin-component/src/lib.rs
+++ b/spin-component/src/lib.rs
@@ -3,6 +3,7 @@ mod static_assets;
 mod kv;
 mod data;
 mod email;
+mod inquiry_hub;
 mod seo;
 mod markdown;
 mod pages;
@@ -236,7 +237,7 @@ async fn handle(req: Request) -> anyhow::Result<impl IntoResponse> {
             api::ideas::like(id_str)
         }
         (Method::Get, "/api/qa") => api::qa::list(),
-        (Method::Post, "/api/qa") => api::qa::create(req),
+        (Method::Post, "/api/qa") => api::qa::create(req).await,
         (Method::Post, p) if p.starts_with("/api/qa/") && p.ends_with("/answer") => {
             let id_str = &p[8..p.len() - 7];
             api::qa::answer(id_str, req)

--- a/spin.toml
+++ b/spin.toml
@@ -19,6 +19,7 @@ source = "spin-component/target/wasm32-wasip2/release/enablerdao_spin.wasm"
 description = "EnablerDAO website — Spin HTTP component"
 allowed_outbound_hosts = [
     "https://api.resend.com",
+    "https://labs-enabler.fly.dev",
 ]
 key_value_stores = ["default"]
 


### PR DESCRIPTION
## 概要

公開フォーム5本の送信成功時に、集約ハブ labs-enabler `POST https://labs-enabler.fly.dev/api/inquiry` へ **best-effort（fire-and-forget）で転送**を追加。既存の KV 保存・メール通知・レスポンスは一切変更なし。転送失敗は完全に無視する。

## 対象フォーム

| エンドポイント | slug | 転送タイミング |
|---|---|---|
| `/api/feedback` | enablerdao-feedback | submit 成功時 |
| `/api/ideas` | enablerdao-ideas | create_idea Ok |
| `/api/qa` | enablerdao-qa | create_question Ok |
| `/api/newsletter/subscribe` | enablerdao-newsletter | subscribe Ok |
| `/api/fanclub/register` | enablerdao-fanclub | **新規登録 Ok のみ**（既存会員の再ログインは転送しない） |

## 変更点

- `spin-component/src/inquiry_hub.rs`（新規）: 共通転送ヘルパー。`spin_sdk::http::send(req).await` を inline await（email.rs と同じ作法・WASM に tokio::spawn が無いため）
- `spin.toml`: `allowed_outbound_hosts` に `"https://labs-enabler.fly.dev"` を追加
- `src/api/qa.rs`: `create` を同期 → `async` 化、`src/lib.rs` のルート呼び出しを `.await` に変更
- feedback の email は contact に `@` を含む場合のみ採用、無ければ空文字

## 検証

`spin build`（cargo build --target wasm32-wasip2 --release）成功:
```
    Finished `release` profile [optimized] target(s) in 57.32s
Finished building all Spin components
```
（警告2件は既存の dead_code で本変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)